### PR TITLE
DSND-3000: Retry more error types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
   </parent>
 
   <artifactId>document-store-delta-consumer</artifactId>
@@ -147,6 +147,10 @@
           <groupId>io.grpc</groupId>
           <artifactId>grpc-context</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -183,6 +187,10 @@
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-webapp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/uk/gov/companieshouse/documentstore/consumer/apiclient/DocumentApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/documentstore/consumer/apiclient/DocumentApiResponseHandler.java
@@ -2,9 +2,9 @@ package uk.gov.companieshouse.documentstore.consumer.apiclient;
 
 import static uk.gov.companieshouse.documentstore.consumer.Application.NAMESPACE;
 
+import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.documentstore.consumer.exception.NonRetryableException;
@@ -12,8 +12,6 @@ import uk.gov.companieshouse.documentstore.consumer.exception.RetryableException
 import uk.gov.companieshouse.documentstore.consumer.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
-import java.util.List;
 
 @Component
 public class DocumentApiResponseHandler {
@@ -25,23 +23,27 @@ public class DocumentApiResponseHandler {
     private static final String UNEXPECTED_RESPONSE_CODE_MESSAGE = "Unexpected HTTP response code %d when creating document";
 
     public void handle(ApiErrorResponseException ex) {
+
         final int statusCode = ex.getStatusCode();
-        if (HttpStatus.valueOf(statusCode).is5xxServerError()) {
-            LOGGER.info(API_ERROR_RESPONSE_MESSAGE.formatted(statusCode), DataMapHolder.getLogMap());
-            throw new RetryableException(API_ERROR_RESPONSE_MESSAGE.formatted(statusCode), ex);
+        String message = API_ERROR_RESPONSE_MESSAGE.formatted(statusCode);
+
+        if (HttpStatus.BAD_REQUEST.value() == ex.getStatusCode() || HttpStatus.CONFLICT.value() == ex.getStatusCode()) {
+            LOGGER.error(message, ex, DataMapHolder.getLogMap());
+            throw new NonRetryableException(message, ex);
         } else {
-            LOGGER.error(API_ERROR_RESPONSE_MESSAGE.formatted(statusCode), DataMapHolder.getLogMap());
-            throw new NonRetryableException(API_ERROR_RESPONSE_MESSAGE.formatted(statusCode), ex);
+            LOGGER.info(String.format("%s. %s", message, Arrays.toString(ex.getStackTrace())),
+                    DataMapHolder.getLogMap());
+            throw new RetryableException(message, ex);
         }
     }
 
     public void handle(URIValidationException ex) {
-        LOGGER.error(URI_VALIDATION_EXCEPTION_MESSAGE, DataMapHolder.getLogMap());
+        LOGGER.error(URI_VALIDATION_EXCEPTION_MESSAGE, ex, DataMapHolder.getLogMap());
         throw new NonRetryableException(URI_VALIDATION_EXCEPTION_MESSAGE, ex);
     }
 
     public void handleNullResponse() {
-        LOGGER.error(NULL_RESPONSE_EXCEPTION_MESSAGE, DataMapHolder.getLogMap());
+        LOGGER.info(NULL_RESPONSE_EXCEPTION_MESSAGE, DataMapHolder.getLogMap());
         throw new RetryableException(NULL_RESPONSE_EXCEPTION_MESSAGE);
     }
 

--- a/src/main/java/uk/gov/companieshouse/documentstore/consumer/apiclient/FilingHistoryDocumentMetadataApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/documentstore/consumer/apiclient/FilingHistoryDocumentMetadataApiResponseHandler.java
@@ -31,9 +31,7 @@ public class FilingHistoryDocumentMetadataApiResponseHandler {
     }
 
     private boolean isRetryableStatusCode(int statusCode) {
-        HttpStatus httpStatus = HttpStatus.valueOf(statusCode);
-        // retry 5XX errors and 404 errors as 404 could be down to FH delta processing times
-        return httpStatus.is5xxServerError() || httpStatus == HttpStatus.NOT_FOUND;
+        return !(HttpStatus.BAD_REQUEST.value() == statusCode || HttpStatus.CONFLICT.value() == statusCode);
     }
 
     public void handle(URIValidationException ex) {


### PR DESCRIPTION
* All API client errors, apart from 400 and 409, are now retryable
* Updated the parent POM version to pull in the security check changes
* Updated POM to exclude some dependencies with CVEs. Needs a Spring version upgrade

[DSND-3000](https://companieshouse.atlassian.net/browse/DSND-3000)

[DSND-3000]: https://companieshouse.atlassian.net/browse/DSND-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ