### PR TITLE
ASM-1487: Spring upgrade and CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,8 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.5.9</spring.boot.version>
+    <spring.boot.version>4.0.6</spring.boot.version>
     <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
-    <test-containers.version>1.20.2</test-containers.version>
     <maven-surefire.version>3.5.1</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
@@ -30,11 +29,11 @@
     <skip.integration.tests>false</skip.integration.tests>
 
     <!--companies house-->
-    <structured-logging.version>3.0.51</structured-logging.version>
+    <structured-logging.version>3.0.57</structured-logging.version>
     <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.443</private-api-sdk-java.version>
+    <private-api-sdk-java.version>7.0.4</private-api-sdk-java.version>
     <data-sync-api-sdk-java.version>1.0.10</data-sync-api-sdk-java.version>
-    <kafka-models.version>3.0.26</kafka-models.version>
+    <kafka-models.version>3.0.35</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -52,17 +51,19 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Addresses CVE-2026-2332 across all org.eclipse.jetty.ee10:* artifacts; declared before
+           spring-boot-dependencies so first-wins BOM resolution pins the whole jetty-ee10 family -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>12.0.35</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${test-containers.version}</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -108,7 +109,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-aop</artifactId>
+      <artifactId>spring-boot-starter-aspectj</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -207,6 +208,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
@@ -230,12 +236,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,12 +230,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.jayway.jsonpath</groupId>
-          <artifactId>json-path</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <maven.compiler.target>21</maven.compiler.target>
     <spring.boot.version>4.0.7</spring.boot.version>
     <!-- Override the tomcat-embed-core version managed by the spring-boot-dependencies BOM
-         to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404, CVE-2026-55956.
-         Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
+         to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404, CVE-2026-55956,
+         CVE-2026-55955. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
     <tomcat.version>11.0.23</tomcat.version>
     <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
     <maven-surefire.version>3.5.1</maven-surefire.version>
@@ -62,11 +62,12 @@
       </dependency>
       <!-- Override every tomcat-embed-* artifact managed by spring-boot-dependencies
            to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404,
-           CVE-2026-55956. The CVEs apply to Tomcat itself, so every tomcat-embed-*
-           sibling is flagged at the same version. A <tomcat.version> property
-           override has no effect on imported BOMs (only on parent inheritance),
-           so each artifact must be pinned via an explicit dependencyManagement
-           entry. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
+           CVE-2026-55956, CVE-2026-55955. The CVEs apply to Tomcat itself, so every
+           tomcat-embed-* sibling is flagged at the same version. A <tomcat.version>
+           property override has no effect on imported BOMs (only on parent
+           inheritance), so each artifact must be pinned via an explicit
+           dependencyManagement entry. Drop once a Spring Boot 4.0.x patch bumps
+           Tomcat for us. -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <xmlunit-core.version>2.10.0</xmlunit-core.version>
     <avro.version>1.12.1</avro.version>
     <lz4-java-fork.version>1.10.2</lz4-java-fork.version>
+    <guava.version>33.6.0-jre</guava.version>
 
     <!--sonar configuration-->
     <sonar.coverage.jacoco.xmlReportPaths>
@@ -115,6 +116,13 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>2.25.4</version>
+    </dependency>
+    <!-- Pinning version (and switching android -> jre flavour) to address CVE-2023-2976;
+         pulled in transitively by kafka-models -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <spring.boot.version>4.0.6</spring.boot.version>
+    <!-- Override the tomcat-embed-core version managed by the spring-boot-dependencies BOM
+         to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512, CVE-2026-42498,
+         CVE-2026-43515. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
+    <tomcat.version>11.0.22</tomcat.version>
     <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
     <maven-surefire.version>3.5.1</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
@@ -38,9 +42,7 @@
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <xmlunit-core.version>2.10.0</xmlunit-core.version>
     <avro.version>1.12.1</avro.version>
-    <!-- TODO: lz4-java CVEs (CVE-2025-12183, CVE-2025-66566) require at.yawk.lz4:lz4-java:1.10.1
-         The original org.lz4:lz4-java is discontinued. The artifact at.yawk.lz4:lz4-java:1.10.1
-         needs to be added to the company's artifact repository to fix these vulnerabilities -->
+    <lz4-java-fork.version>1.10.2</lz4-java-fork.version>
 
     <!--sonar configuration-->
     <sonar.coverage.jacoco.xmlReportPaths>
@@ -51,21 +53,35 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Addresses CVE-2026-2332 across all org.eclipse.jetty.ee10:* artifacts; declared before
-           spring-boot-dependencies so first-wins BOM resolution pins the whole jetty-ee10 family -->
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-bom</artifactId>
-        <version>12.0.35</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Override every tomcat-embed-* artifact managed by spring-boot-dependencies
+           to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512,
+           CVE-2026-42498, CVE-2026-43515. The CVEs apply to Tomcat itself, so every
+           tomcat-embed-* sibling is flagged at the same version. A <tomcat.version>
+           property override has no effect on imported BOMs (only on parent
+           inheritance), so each artifact must be pinned via an explicit
+           dependencyManagement entry. Drop once a Spring Boot 4.0.x patch bumps
+           Tomcat for us. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -106,6 +122,20 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
+      <exclusions>
+        <!-- org.lz4:lz4-java 1.8.0 is abandoned upstream; replaced below with maintained fork.
+             CVE-2025-12183, CVE-2025-66566, GHSA-cmp6-m4wj-q63q, GHSA-vqf4-7m7x-wgfc -->
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Drop-in API-compatible community fork of the abandoned org.lz4:lz4-java -->
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>${lz4-java-fork.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <spring.boot.version>4.0.7</spring.boot.version>
+    <ch-dependency-bom.version>0.1.10</ch-dependency-bom.version>
     <!-- Override the tomcat-embed-core version managed by the spring-boot-dependencies BOM
          to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404, CVE-2026-55956,
          CVE-2026-55955. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
@@ -33,11 +34,8 @@
     <skip.integration.tests>false</skip.integration.tests>
 
     <!--companies house-->
-    <structured-logging.version>3.0.57</structured-logging.version>
-    <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
     <private-api-sdk-java.version>7.0.4</private-api-sdk-java.version>
     <data-sync-api-sdk-java.version>1.0.10</data-sync-api-sdk-java.version>
-    <kafka-models.version>3.0.35</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -53,6 +51,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Import CH BOM first so CH-approved versions (CVE overrides) take precedence -->
+      <dependency>
+        <groupId>uk.gov.companieshouse</groupId>
+        <artifactId>ch-dependency-bom</artifactId>
+        <version>${ch-dependency-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Then Spring Boot BOM -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -164,12 +171,10 @@
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
-      <version>${structured-logging.version}</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>sdk-manager-java</artifactId>
-      <version>${sdk-manager-java.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-collections</groupId>
@@ -204,7 +209,6 @@
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>kafka-models</artifactId>
-      <version>${kafka-models.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-fileupload</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>4.0.6</spring.boot.version>
+    <spring.boot.version>4.0.7</spring.boot.version>
     <!-- Override the tomcat-embed-core version managed by the spring-boot-dependencies BOM
-         to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512, CVE-2026-42498,
-         CVE-2026-43515. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
-    <tomcat.version>11.0.22</tomcat.version>
+         to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404, CVE-2026-55956.
+         Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
+    <tomcat.version>11.0.23</tomcat.version>
     <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
     <maven-surefire.version>3.5.1</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
@@ -61,13 +61,12 @@
         <scope>import</scope>
       </dependency>
       <!-- Override every tomcat-embed-* artifact managed by spring-boot-dependencies
-           to fix CVE-2026-41293, CVE-2026-41284, CVE-2026-43513, CVE-2026-43512,
-           CVE-2026-42498, CVE-2026-43515. The CVEs apply to Tomcat itself, so every
-           tomcat-embed-* sibling is flagged at the same version. A <tomcat.version>
-           property override has no effect on imported BOMs (only on parent
-           inheritance), so each artifact must be pinned via an explicit
-           dependencyManagement entry. Drop once a Spring Boot 4.0.x patch bumps
-           Tomcat for us. -->
+           to fix CVE-2026-50229, CVE-2026-55276, CVE-2026-53434, CVE-2026-53404,
+           CVE-2026-55956. The CVEs apply to Tomcat itself, so every tomcat-embed-*
+           sibling is flagged at the same version. A <tomcat.version> property
+           override has no effect on imported BOMs (only on parent inheritance),
+           so each artifact must be pinned via an explicit dependencyManagement
+           entry. Drop once a Spring Boot 4.0.x patch bumps Tomcat for us. -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
@@ -103,15 +102,22 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.19.0</version>
     </dependency>
+    <!-- Pinning version to address CVE-2026-34477, CVE-2026-34479 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
       <version>0.9.6</version>
+    </dependency>
+    <!-- Pinning version to address CVE-2025-67030 (directory traversal in Expand.extractFile) -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.0.3</version>
     </dependency>
     <!--end transitive dependencies-->
 

--- a/src/main/java/uk/gov/companieshouse/documentstore/consumer/kafka/MessageFlags.java
+++ b/src/main/java/uk/gov/companieshouse/documentstore/consumer/kafka/MessageFlags.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.documentstore.consumer.kafka;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.show-details=never
 management.endpoint.health.enabled=true
-management.health.mongo.enabled=false
+management.health.mongodb.enabled=false
 
 set-no-deletion-header=${DOCUMENT_STORE_NO_DELETION:true}
 transaction-id-salt=${TRANSACTION_ID_SALT:salt}

--- a/src/test/java/uk/gov/companieshouse/documentstore/consumer/DocumentStoreApplicationIT.java
+++ b/src/test/java/uk/gov/companieshouse/documentstore/consumer/DocumentStoreApplicationIT.java
@@ -3,15 +3,15 @@ package uk.gov.companieshouse.documentstore.consumer;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
@@ -33,6 +33,6 @@ class DocumentStoreApplicationIT {
                         .header(REQUEST_ID.value(), "request_id"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string("{\"status\":\"UP\"}"));
+                .andExpect(jsonPath("$.status").value("UP"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/documentstore/consumer/kafka/ConsumerNonRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/documentstore/consumer/kafka/ConsumerNonRetryableExceptionIT.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.documentstore.consumer.exception.NonRetryableException;
 import uk.gov.companieshouse.documentstore.consumer.service.DeltaService;
@@ -43,7 +43,7 @@ class ConsumerNonRetryableExceptionIT extends AbstractKafkaIT {
     @Autowired
     private TestConsumerAspect testConsumerAspect;
 
-    @MockBean
+    @MockitoBean
     private DeltaService deltaService;
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/documentstore/consumer/kafka/ConsumerRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/documentstore/consumer/kafka/ConsumerRetryableExceptionIT.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.documentstore.consumer.exception.RetryableException;
 import uk.gov.companieshouse.documentstore.consumer.service.DeltaService;
@@ -44,7 +44,7 @@ class ConsumerRetryableExceptionIT extends AbstractKafkaIT {
     @Autowired
     private TestConsumerAspect testConsumerAspect;
 
-    @MockBean
+    @MockitoBean
     private DeltaService deltaService;
 
     @DynamicPropertySource


### PR DESCRIPTION
Spring Boot 4 upgrade + Critical CVE fixes (ASM-1487)

Upgrades document-store-delta-consumer from Spring Boot 3.5.9 to 4.0.6 (Spring Framework 7, Tomcat 11, Spring Kafka 4) to close out the Critical CVEs flagged by Dependency Track: spring-boot-actuator-autoconfigure (CVE-2026-40976) and spring-boot-autoconfigure (CVE-2026-40971/40974) are fixed directly by the Boot 4.0.6 bump; tomcat-embed-core needed an explicit version pin (11.0.22) since Boot 4.0.6's bundled Tomcat (11.0.21) doesn't cover all of the flagged advisories

Includes the mechanical fallout of the Boot 4 migration: javax.* to jakarta.* namespace move. Cross-referenced against three sibling repos that did the same upgrade to keep the change minimal and avoid unnecessary overrides (an initial jetty-ee10-bom override copied from those siblings turned out to be inert here and was dropped).
